### PR TITLE
chore: remove obsolete header

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,3 @@
-# AUTO-GENERATED, DO NOT EDIT!
-# Please edit the original at https://github.com/ory/meta/blob/master/templates/repository/common/.github/workflows/format.yml
-
 name: Format
 
 on:


### PR DESCRIPTION
The "format" CI task is stand-alone again.